### PR TITLE
Use provided database name

### DIFF
--- a/src/daleco/database/DaleCoDatabase.java
+++ b/src/daleco/database/DaleCoDatabase.java
@@ -113,7 +113,11 @@ public class DaleCoDatabase {
 			e.printStackTrace();
 		} finally {
 			if (resultSet != null) {
-				resultSet.close();
+				try {
+					resultSet.close();
+				} catch(Exception e) {
+					e.printStackTrace();
+				}
 			}
 		}
 

--- a/src/daleco/database/DaleCoDatabase.java
+++ b/src/daleco/database/DaleCoDatabase.java
@@ -105,21 +105,19 @@ public class DaleCoDatabase {
 	}
 	
 	public boolean productTableExists(){
-	    try {
-	        ResultSet resultSet = connection.getMetaData().getTables(null, null, "%", null);
+		ResultSet resultSet = null;
+		try {
+			resultSet = connection.getMetaData().getTables(null, null, "products", null);
+			return resultSet.next();
+		} catch(Exception e) {
+			e.printStackTrace();
+		} finally {
+			if (resultSet != null) {
+				resultSet.close();
+			}
+		}
 
-	        while (resultSet.next()) {
-	          String tableName = resultSet.getString(3);
-	            if(tableName.equals("products")){
-	                return true;
-	            }
-	        }
-	        resultSet.close();
-	    } catch(Exception e) {
-	        e.printStackTrace();
-	    }
-
-	    return false;
+		return false;
 	}
 	
 	public void close() {

--- a/src/daleco/database/DaleCoDatabase.java
+++ b/src/daleco/database/DaleCoDatabase.java
@@ -27,11 +27,12 @@ public class DaleCoDatabase {
 			System.out.println("User: " + dbconfig.GetUser());
 			System.out.println("Password: " + dbconfig.GetPassword());
 			System.out.println("Host: " + dbconfig.GetHost());
-			
+			System.out.println("Database name: " + dbconfig.GetDatabaseName());
+
 			System.out.println("Initializing database driver ...");
 
 			System.out.println("Connecting to Database");
-			constring = "jdbc:mysql://" + dbconfig.GetHost() + "/?user=" + dbconfig.GetUser() + "&password=" + dbconfig.GetPassword();
+			constring = "jdbc:mysql://" + dbconfig.GetHost() + "/" + dbconfig.GetDatabaseName() + "?user=" + dbconfig.GetUser() + "&password=" + dbconfig.GetPassword();
 			Class.forName("com.mysql.jdbc.Driver");
 			
 			System.out.println("Connection String:" + constring);
@@ -62,15 +63,8 @@ public class DaleCoDatabase {
 		}
 		
 		try {
-			System.out.println("Creating Database");
-			statement = this.connection
-                    .prepareStatement("CREATE DATABASE inventory;");
-			statement.execute();
-			
-			
 			System.out.println("Creating table: Products");
-			statement.close();
-			statement = connection.prepareStatement("CREATE TABLE inventory.products (product_id int not NULL primary key, description CHAR (200), image_name CHAR(200));");
+			statement = connection.prepareStatement("CREATE TABLE products (product_id int not NULL primary key, description CHAR (200), image_name CHAR(200));");
 			statement.execute();
 			statement.close();
 			
@@ -83,7 +77,7 @@ public class DaleCoDatabase {
 	            Statement batchStatment = connection.createStatement();
 	            while((line = bufferedReader.readLine()) != null) {
 	                String[] d = line.split(",");
-	                String sql = "INSERT INTO inventory.products VALUES('" + d[0] + "','" + d[1] + "','" + d[2] + "')";
+	                String sql = "INSERT INTO products VALUES('" + d[0] + "','" + d[1] + "','" + d[2] + "')";
 	                System.out.println("Adding: " + sql);
 	                batchStatment.addBatch(sql);
 	            } 
@@ -110,20 +104,18 @@ public class DaleCoDatabase {
 		}
 	}
 	
-	public boolean dbExsits(){
-	    try{
-
-	        ResultSet resultSet = connection.getMetaData().getCatalogs();
+	public boolean productTableExists(){
+	    try {
+	        ResultSet resultSet = connection.getMetaData().getTables(null, null, "%", null);
 
 	        while (resultSet.next()) {
-	          String databaseName = resultSet.getString(1);
-	            if(databaseName.equals("inventory")){
+	          String tableName = resultSet.getString(3);
+	            if(tableName.equals("products")){
 	                return true;
 	            }
 	        }
 	        resultSet.close();
-	    }
-	    catch(Exception e){
+	    } catch(Exception e) {
 	        e.printStackTrace();
 	    }
 

--- a/src/daleco/database/DatabaseConfig.java
+++ b/src/daleco/database/DatabaseConfig.java
@@ -1,21 +1,26 @@
 package daleco.database;
 
 public class DatabaseConfig {
-	private String user = "";
-	private String password = "";
-	private String host = "";
+	private final String user;
+	private final String password;
+	private final String host;
+	private final String databaseName;
 
-	public DatabaseConfig(String user, String password, String host) {
+	public DatabaseConfig(String user, String password, String host, String databaseName) {
 		this.user = user;
 		this.password = password;
 		this.host = host;
+		this.databaseName = databaseName;
 	}
-	
-
 
 	public String GetHost() {
 		return this.host;
 	}
+
+	public String GetDatabaseName() {
+		return this.databaseName;
+	}
+
 	public String GetUser() {
 		return this.user;
 	}

--- a/src/daleco/database/DatabaseGetPropertyValues.java
+++ b/src/daleco/database/DatabaseGetPropertyValues.java
@@ -25,8 +25,9 @@ public class DatabaseGetPropertyValues {
 			String user = prop.getProperty("user");
 			String password = prop.getProperty("password");
 			String host = prop.getProperty("host");
+			String databaseName = prop.getProperty("database");
  
-			dbconfig = new DatabaseConfig(user, password, host);
+			dbconfig = new DatabaseConfig(user, password, host, databaseName);
 			
 		} catch (Exception e) {
 			System.out.println("Exception: " + e);

--- a/src/daleco/database/Inventory.java
+++ b/src/daleco/database/Inventory.java
@@ -29,9 +29,8 @@ public class Inventory {
 		try {
 			DaleCoDatabase db = new DaleCoDatabase();
 			Connection connection = db.getConnection();
-			connection.setCatalog("inventory");
 			
-			PreparedStatement statement = connection.prepareStatement("SELECT product_id, description, image_name from inventory.products;");
+			PreparedStatement statement = connection.prepareStatement("SELECT product_id, description, image_name from products;");
 			ResultSet rs = statement.executeQuery();
 			
 			while(rs.next()) {

--- a/src/daleco/initialization/Initializer.java
+++ b/src/daleco/initialization/Initializer.java
@@ -33,11 +33,11 @@ public class Initializer extends HttpServlet {
 			DaleCoDatabase db = new DaleCoDatabase();
 			
 			
-			if(db.dbExsits()) {
-				System.out.println("Daleco database exists, continuing with initialization.");
+			if(db.productTableExists()) {
+				System.out.println("Daleco product table exists, continuing with initialization.");
 			}
 			else {
-				System.out.println("Daleco database not found, creating ...");
+				System.out.println("Daleco product table not found, creating ...");
 				db.create();
 			}
 			


### PR DESCRIPTION
Use the database name provided by Stacksmith instead of creating a
new one when the application launches. This will be necessary in the
case where the database user created by Stacksmith does not have
permission to create a new database.