### PR TITLE
boot.sh: fix config dir & write all db properties

### DIFF
--- a/boot.sh
+++ b/boot.sh
@@ -5,24 +5,17 @@ set -euo pipefail
 
 readonly CONF=WEB-INF/classes/database.properties
 
+# Change to webapp directory. Assumes there's only one webapp unpacked to tomcat.
+cd $(find /var/lib/tomcat/webapps/ -type d -mindepth 1 -maxdepth 1 | head -n 1)
+
 echo "current directory: " $PWD
 echo "writing to file: " $CONF
 
-
-echo "host=${DATABASE_HOST}" > $CONF
-echo "user=${DATABASE_USER}" >> $CONF
-echo "password=${DATABASE_PASSWORD}" >> $CONF
-
-
-#sed -i -e "host#s#=${DATABASE_HOST}#" "$CONF"
-#sed -i -e "user#s#=${DATABASE_USER}#" "$CONF"
-#sed -i -e "password#s#=${DATABASE_PASSWORD}#" "$CONF"
-
-
-
-# DATABASE_HOST: The hostname to use to connect to the database
-# DATABASE_USER: The root username for the database. You can connect as this user and create other users if you require
-# DATABASE_PASSWORD: The password for the root database user
-
-
-
+# Write database config
+cat > "${CONF}" <<-EOF
+type=${DATABASE_TYPE}
+host=${DATABASE_HOST}
+database=${DATABASE_NAME}
+user=${DATABASE_USER}
+password=${DATABASE_PASSWORD}
+EOF

--- a/boot.sh
+++ b/boot.sh
@@ -1,17 +1,33 @@
 #!/bin/bash
 
-#use set to enable verbose output
+# This script configures the DaleCo example web app according to the following
+# environment variables:
+#
+#   DATABASE_TYPE:
+#       The type of database server - "mysql" or "postgres"
+#   DATABASE_HOST:
+#       The hostname to use to connect to the database
+#   DATABASE_NAME:
+#       The name of the database.
+#   DATABASE_USER:
+#       The root username for the database. You can connect as this user and
+#       create other users if you require
+#   DATABASE_PASSWORD:
+#       The password for the root database user
+
+
+# use set to enable verbose output
 set -euo pipefail
 
 readonly CONF=WEB-INF/classes/database.properties
 
-# Change to webapp directory. Assumes there's only one webapp unpacked to tomcat.
+# change to webapp directory. Assumes there's only one webapp unpacked to tomcat.
 cd $(find /var/lib/tomcat/webapps/ -type d -mindepth 1 -maxdepth 1 | head -n 1)
 
 echo "current directory: " $PWD
 echo "writing to file: " $CONF
 
-# Write database config
+# write database config
 cat > "${CONF}" <<-EOF
 type=${DATABASE_TYPE}
 host=${DATABASE_HOST}


### PR DESCRIPTION
Fix the boot.sh to work out-of-the-box:

The script needs to write `database.properties` to the correct directory. Fixed using a bit of a hack as all it can do is assume there's one deployed web app and write the config there.

DaleCo supports mysql and postgresql, the `DATABASE_TYPE` property is required. `DATABASE_NAME` was also missing.